### PR TITLE
Send better html email

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -33,7 +33,7 @@ exports.submit = (req, res) => {
     subject: 'grocery list',
     text:
       'Sorry, at the moment there is nothing to see here in the plain text version :(JSON.stringify(outputObj, null, 2)',
-    html: `<pre>${JSON.stringify(req.body, null, 2)}</pre>`
+    html: req.body.data
   };
 
   transporter.sendMail(mailOptions, (error, info) => {


### PR DESCRIPTION
This PR updates the `html` value of the `mailOptions` object in the `submit` controller.

I had to recognize that Express expects to accept an object for the value of `req.body`. Before achieving this solution, I was posting html as a string to be the value of `req.body`, and so Express outputted some where object where the first opening html tag was the object key, and the rest of the string was the value.

This PR helps solve https://github.com/brianzelip/groceries-vue/issues/7.