### PR TITLE
Respond to post create

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,10 +21,19 @@ This document started at v0.5.0.
      - new controller
 
 3. Send submitted grocery list to the correct email addresses
+
    - starting point: v0.7.0
    - starting branch: handle-email-data
    - ending point: v0.8.0
    - steps:
      - handle email data passed from front end
+
+4. Send created item info response on `post('/create')`
+
+- starting point: v0.8.0
+- starting branch: respond-to-post-create
+- ending point: v0.9.0
+- steps:
+  - send response back before ending create controller
 
 \* a personal take

--- a/controller.js
+++ b/controller.js
@@ -50,10 +50,17 @@ exports.submit = (req, res) => {
   });
 };
 
-exports.createItem = async req => {
+exports.createItem = async (req, res) => {
   const item = new Item(req.body);
-  await item.save();
-  console.log("newItem savedD! Here's the data:::\n\n", item);
+  await item
+    .save()
+    .then(createdItem => {
+      console.log("newItem savedD! Here's the data:::\n\n", createdItem);
+      return createdItem;
+    })
+    .then(createdItem => {
+      res.send(createdItem);
+    });
 };
 
 exports.updateItem = async req => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "groceries-vue-api",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groceries-vue-api",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Data API for the groceries web app rewritten in Vue.js.",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
This PR sends a response back to the `post('/create')` route request with the created item data. Closes #14.